### PR TITLE
test: add wolfram unity golden cases

### DIFF
--- a/engine/trace/golden/wolfram_unity.json
+++ b/engine/trace/golden/wolfram_unity.json
@@ -1,0 +1,68 @@
+[
+  {
+    "test": "ask_act_gate_allows_low_risk",
+    "assertion": {
+      "gate": "ask_act",
+      "expected": "open"
+    },
+    "result": {
+      "status": "open",
+      "evidence": "risk_below_threshold"
+    },
+    "bits": {
+      "A": 1.0,
+      "U": 0.1,
+      "P": 1.0,
+      "E": 0.2,
+      "Δ": 0.0,
+      "I": 0.6,
+      "R": 0.4,
+      "T": 0.8,
+      "M": 0.1
+    }
+  },
+  {
+    "test": "evidence_gate_requires_confirmation",
+    "assertion": {
+      "gate": "evidence",
+      "expected": "collect"
+    },
+    "result": {
+      "status": "collect",
+      "reason": "uncertainty_above_threshold"
+    },
+    "bits": {
+      "A": 0.9,
+      "U": 0.7,
+      "P": 1.0,
+      "E": 0.9,
+      "Δ": 0.0,
+      "I": 0.5,
+      "R": 0.3,
+      "T": 0.6,
+      "M": 0.2
+    }
+  },
+  {
+    "test": "caps_gate_blocks_high_risk_write",
+    "assertion": {
+      "gate": "caps",
+      "expected": "deny"
+    },
+    "result": {
+      "status": "deny",
+      "policy": "caps_network_write"
+    },
+    "bits": {
+      "A": 0.2,
+      "U": 0.8,
+      "P": 1.0,
+      "E": 1.0,
+      "Δ": 0.4,
+      "I": 0.3,
+      "R": 0.9,
+      "T": 0.5,
+      "M": 0.0
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add curated wolfram_unity golden scenarios under engine/trace/golden to satisfy the existing validation test

## Testing
- cargo test --all --locked

------
https://chatgpt.com/codex/tasks/task_e_68d1b6e74068832190a4c70d41a9dec5

---
## EntelligenceAI PR Summary 
 This PR adds a new golden test file for the Wolfram Unity trace system with three test cases.
- Added test for 'ask_act' gate verifying it allows operations with low risk scores
- Added test for 'evidence' gate confirming it requires additional confirmation when uncertainty is above threshold
- Added test for 'caps' gate ensuring it blocks high-risk write operations
- Each test includes expected behavior, actual results, and specific bit values 

