### PR TITLE
feat: add research summary report generation

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -16,7 +16,7 @@ field-publish:
 	@python3 scripts/field_publish.py field/*.md
 
 .PHONY: research-index
-research-index: ; cargo run --bin one-research -- --root . --out research/index.jsonl
+research-index: ; cargo run --bin one-research -- --root . --out research/index.jsonl --report-out research/report.json
 
 # Meta² Chat Interface
 chat: ; ./meta2-chat $(USER) $(KEY) $(THREAD)

--- a/engine/_output/ARCHITECTURE_CONTEXT.md
+++ b/engine/_output/ARCHITECTURE_CONTEXT.md
@@ -45,7 +45,7 @@ This document compiles the essential context to derive ONE production architectu
 - Use for regression + CI gates.
 
 ## 7) Research Library (Compression)
-- Indexer: `one-research` binary (or `make research-index`) builds `research/index.jsonl`.
+- Indexer: `one-research` binary (or `make research-index`) builds `research/index.jsonl` and freshness report `research/report.json`.
 - Sources: prompts, policies, schemas, docs, golden.
 - Provenance: checksum + git branch/commit.
 
@@ -83,7 +83,7 @@ This document compiles the essential context to derive ONE production architectu
 - Chat demo: `curl -s -X POST -H 'x-api-key: demo-key-123' -H 'content-type: application/json' http://127.0.0.1:8080/users/demo/chat -d '{"message":"hello"}'`
 - Meta pick: `curl -s -X POST -H 'content-type: application/json' http://127.0.0.1:8080/meta/run -d '{"task":"compress_chatlog"}'`
 - Golden validate: `curl -s -X POST -H 'content-type: application/json' http://127.0.0.1:8080/validate_golden -d '{"name":"wolfram_unity"}'`
-- Research index: `make research-index`
+- Research index/report: `make research-index`
 
 ---
 

--- a/engine/bin/one_research.rs
+++ b/engine/bin/one_research.rs
@@ -1,25 +1,54 @@
-use std::{path::PathBuf, fs::File, io::Write};
 use one_engine::research;
+use std::{fs::File, io::Write, path::PathBuf};
 
 fn main() -> anyhow::Result<()> {
     let mut roots: Vec<PathBuf> = vec![PathBuf::from(".")];
     let mut out = PathBuf::from("research/index.jsonl");
+    let mut report_out: Option<PathBuf> = None;
     let mut args = std::env::args().skip(1);
     while let Some(a) = args.next() {
         match a.as_str() {
-            "--root" => if let Some(v) = args.next() { roots.push(PathBuf::from(v)); },
-            "--out" => if let Some(v) = args.next() { out = PathBuf::from(v); },
+            "--root" => {
+                if let Some(v) = args.next() {
+                    roots.push(PathBuf::from(v));
+                }
+            }
+            "--out" => {
+                if let Some(v) = args.next() {
+                    out = PathBuf::from(v);
+                }
+            }
+            "--report" => {
+                report_out = Some(PathBuf::from("research/report.json"));
+            }
+            "--report-out" => {
+                if let Some(v) = args.next() {
+                    report_out = Some(PathBuf::from(v));
+                }
+            }
             _ => {}
         }
     }
     let artifacts = research::build_index_multi(&roots)?;
-    if let Some(parent) = out.parent() { std::fs::create_dir_all(parent)?; }
+    if let Some(parent) = out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     let mut f = File::create(&out)?;
-    for a in artifacts {
-        let line = serde_json::to_string(&a)?;
+    for a in &artifacts {
+        let line = serde_json::to_string(a)?;
         f.write_all(line.as_bytes())?;
         f.write_all(b"\n")?;
     }
     eprintln!("wrote {}", out.display());
+    if let Some(report_path) = report_out {
+        if let Some(parent) = report_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let summary = research::summarize(&artifacts, chrono::Utc::now());
+        let mut rf = File::create(&report_path)?;
+        serde_json::to_writer_pretty(&mut rf, &summary)?;
+        rf.write_all(b"\n")?;
+        eprintln!("wrote {}", report_path.display());
+    }
     Ok(())
 }

--- a/engine/docs/RESEARCH_LIBRARY.md
+++ b/engine/docs/RESEARCH_LIBRARY.md
@@ -17,11 +17,13 @@ A compact, auditable collection of prompts, policies, schemas, traces, and docs 
 - See `schemas/RESEARCH_ARTIFACT.schema.json`.
 - Minimal fields: `{id, kind, path, ts, ttl, tags, checksum}`
 
-## Building the Index
+## Building the Index & Reports
 - CLI: `one-research` (binary in this crate)
-- Example:
-  - cargo run --bin one-research -- --root . --out research/index.jsonl
-  - Or via Make: `make research-index`
+- Examples:
+  - `cargo run --bin one-research -- --root . --out research/index.jsonl`
+  - `cargo run --bin one-research -- --root . --report-out research/report.json`
+  - Or via Make: `make research-index` (writes both the index and `research/report.json`)
+- The report surfaces counts by kind/tag/branch plus TTL-based freshness alerts.
 
 ## Bringing External Repos
 - Option A: clone them under `external/` and run the indexer with `--root external`.

--- a/engine/src/research.rs
+++ b/engine/src/research.rs
@@ -1,6 +1,7 @@
-use serde::{Serialize, Deserialize};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, fs, io::Read, path::Path, time::SystemTime};
 use walkdir::WalkDir;
-use std::{fs, io::Read, path::Path, time::SystemTime};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ResearchArtifact {
@@ -15,14 +16,52 @@ pub struct ResearchArtifact {
     pub git_branch: Option<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct ExpiringArtifact {
+    pub path: String,
+    pub expires_at: String,
+    pub seconds_remaining: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct TimeSpan {
+    pub earliest: String,
+    pub latest: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct ResearchSummary {
+    pub total: usize,
+    pub by_kind: BTreeMap<String, usize>,
+    pub by_tag: BTreeMap<String, usize>,
+    pub by_branch: BTreeMap<String, usize>,
+    pub untagged: usize,
+    pub missing_git_commit: usize,
+    pub time_span: Option<TimeSpan>,
+    pub expiring_soon: Vec<ExpiringArtifact>,
+    pub expired: Vec<ExpiringArtifact>,
+}
+
 fn kind_for(path: &Path) -> String {
     let p = path.to_string_lossy().to_lowercase();
-    if p.contains("/prompts/") { return "prompt".into(); }
-    if p.contains("/policies/") { return "policy".into(); }
-    if p.contains("/schemas/") { return "schema".into(); }
-    if p.contains("/trace/golden/") { return "trace".into(); }
-    if p.contains("/docs/") || p.ends_with("readme.md") { return "doc".into(); }
-    if p.ends_with(".json") || p.ends_with(".yaml") || p.ends_with(".yml") { return "dataset".into(); }
+    if p.contains("/prompts/") {
+        return "prompt".into();
+    }
+    if p.contains("/policies/") {
+        return "policy".into();
+    }
+    if p.contains("/schemas/") {
+        return "schema".into();
+    }
+    if p.contains("/trace/golden/") {
+        return "trace".into();
+    }
+    if p.contains("/docs/") || p.ends_with("readme.md") {
+        return "doc".into();
+    }
+    if p.ends_with(".json") || p.ends_with(".yaml") || p.ends_with(".yml") {
+        return "dataset".into();
+    }
     "other".into()
 }
 
@@ -53,25 +92,49 @@ pub fn build_index(root: &Path) -> anyhow::Result<Vec<ResearchArtifact>> {
     let mut out = Vec::new();
     let branch = git_branch().ok();
     for entry in WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
-        if !entry.file_type().is_file() { continue; }
+        if !entry.file_type().is_file() {
+            continue;
+        }
         let path = entry.path();
         let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
-        if !matches!(ext, "md"|"json"|"jsonl"|"yaml"|"yml") { continue; }
+        if !matches!(ext, "md" | "json" | "jsonl" | "yaml" | "yml") {
+            continue;
+        }
         // read file
         let mut f = fs::File::open(path)?;
         let mut buf = Vec::new();
         f.read_to_end(&mut buf)?;
         let checksum = format!("{:08x}", adler32(&buf));
         let ts = ts_from(path);
-        let ttl = if path.to_string_lossy().contains("trace/golden/") { 0 } else { 14 * 24 * 3600 };
-        let rel = path.strip_prefix(root).unwrap_or(path).to_string_lossy().to_string();
+        let ttl = if path.to_string_lossy().contains("trace/golden/") {
+            0
+        } else {
+            14 * 24 * 3600
+        };
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .to_string();
         let kind = kind_for(path);
         // tags from simple front-matter if present
         let mut tags = front_matter_tags(&buf);
-        if tags.is_empty() && kind == "policy" { tags.push("policy".into()); }
+        if tags.is_empty() && kind == "policy" {
+            tags.push("policy".into());
+        }
         let id = format!("{}#{}", rel, checksum);
         let git_commit = git_last_commit(path).ok();
-        out.push(ResearchArtifact { id, kind, path: rel, ts, ttl, tags, checksum, git_commit, git_branch: branch.clone() });
+        out.push(ResearchArtifact {
+            id,
+            kind,
+            path: rel,
+            ts,
+            ttl,
+            tags,
+            checksum,
+            git_commit,
+            git_branch: branch.clone(),
+        });
     }
     Ok(out)
 }
@@ -83,41 +146,262 @@ pub fn build_index_multi(roots: &[std::path::PathBuf]) -> anyhow::Result<Vec<Res
     for r in roots {
         let items = build_index(r)?;
         for a in items.into_iter() {
-            if seen.insert(a.checksum.clone()) { all.push(a); }
+            if seen.insert(a.checksum.clone()) {
+                all.push(a);
+            }
         }
     }
     Ok(all)
+}
+
+fn parse_ts(ts: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(ts)
+        .map(|dt| dt.with_timezone(&Utc))
+        .ok()
+}
+
+pub fn summarize(artifacts: &[ResearchArtifact], now: DateTime<Utc>) -> ResearchSummary {
+    let mut by_kind: BTreeMap<String, usize> = BTreeMap::new();
+    let mut by_tag: BTreeMap<String, usize> = BTreeMap::new();
+    let mut by_branch: BTreeMap<String, usize> = BTreeMap::new();
+    let mut untagged = 0usize;
+    let mut missing_git_commit = 0usize;
+    let mut earliest: Option<DateTime<Utc>> = None;
+    let mut latest: Option<DateTime<Utc>> = None;
+    let mut expiring_soon: Vec<ExpiringArtifact> = Vec::new();
+    let mut expired: Vec<ExpiringArtifact> = Vec::new();
+    let soon_window = Duration::hours(72);
+
+    for art in artifacts {
+        *by_kind.entry(art.kind.clone()).or_insert(0) += 1;
+        if art.tags.is_empty() {
+            untagged += 1;
+        }
+        for tag in &art.tags {
+            *by_tag.entry(tag.clone()).or_insert(0) += 1;
+        }
+        match art.git_branch.as_ref() {
+            Some(branch) if !branch.is_empty() => {
+                *by_branch.entry(branch.clone()).or_insert(0) += 1;
+            }
+            _ => {
+                *by_branch.entry("<unknown>".to_string()).or_insert(0) += 1;
+            }
+        }
+        if art
+            .git_commit
+            .as_ref()
+            .map(|s| s.is_empty())
+            .unwrap_or(true)
+        {
+            missing_git_commit += 1;
+        }
+
+        if let Some(ts) = parse_ts(&art.ts) {
+            earliest = Some(match earliest {
+                Some(cur) => cur.min(ts),
+                None => ts,
+            });
+            latest = Some(match latest {
+                Some(cur) => cur.max(ts),
+                None => ts,
+            });
+
+            if art.ttl > 0 {
+                let expires = ts + Duration::seconds(art.ttl as i64);
+                let remaining = expires - now;
+                let record = ExpiringArtifact {
+                    path: art.path.clone(),
+                    expires_at: expires.to_rfc3339(),
+                    seconds_remaining: remaining.num_seconds(),
+                };
+                if remaining <= Duration::zero() {
+                    expired.push(record);
+                } else if remaining <= soon_window {
+                    expiring_soon.push(record);
+                }
+            }
+        }
+    }
+
+    expiring_soon.sort_by_key(|item| item.seconds_remaining);
+    expired.sort_by_key(|item| item.seconds_remaining);
+
+    let time_span = match (earliest, latest) {
+        (Some(a), Some(b)) => Some(TimeSpan {
+            earliest: a.to_rfc3339(),
+            latest: b.to_rfc3339(),
+        }),
+        _ => None,
+    };
+
+    ResearchSummary {
+        total: artifacts.len(),
+        by_kind,
+        by_tag,
+        by_branch,
+        untagged,
+        missing_git_commit,
+        time_span,
+        expiring_soon,
+        expired,
+    }
 }
 
 fn front_matter_tags(buf: &[u8]) -> Vec<String> {
     // Minimal YAML front-matter parser: --- ... --- at top
     let s = String::from_utf8_lossy(buf);
     let mut lines = s.lines();
-    if !matches!(lines.next(), Some(l) if l.trim()=="---") { return Vec::new(); }
+    if !matches!(lines.next(), Some(l) if l.trim()=="---") {
+        return Vec::new();
+    }
     let mut tags: Vec<String> = Vec::new();
     let mut in_tags = false;
     for line in lines {
         let t = line.trim();
-        if t == "---" { break; }
-        if t.starts_with("tags:") { in_tags = true; continue; }
+        if t == "---" {
+            break;
+        }
+        if t.starts_with("tags:") {
+            in_tags = true;
+            continue;
+        }
         if in_tags {
             if t.starts_with('-') {
                 let val = t.trim_start_matches('-').trim();
-                if !val.is_empty() { tags.push(val.to_string()); }
-            } else if t.is_empty() { break; } else { in_tags = false; }
+                if !val.is_empty() {
+                    tags.push(val.to_string());
+                }
+            } else if t.is_empty() {
+                break;
+            } else {
+                in_tags = false;
+            }
         }
     }
     tags
 }
 
 fn git_branch() -> anyhow::Result<String> {
-    let out = std::process::Command::new("git").arg("rev-parse").arg("--abbrev-ref").arg("HEAD")
+    let out = std::process::Command::new("git")
+        .arg("rev-parse")
+        .arg("--abbrev-ref")
+        .arg("HEAD")
         .output()?;
-    if out.status.success() { Ok(String::from_utf8_lossy(&out.stdout).trim().to_string()) } else { anyhow::bail!("git branch failed") }
+    if out.status.success() {
+        Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    } else {
+        anyhow::bail!("git branch failed")
+    }
 }
 
 fn git_last_commit(path: &Path) -> anyhow::Result<String> {
-    let out = std::process::Command::new("git").args(["log","-n","1","--pretty=%h","--", path.to_string_lossy().as_ref()])
+    let out = std::process::Command::new("git")
+        .args([
+            "log",
+            "-n",
+            "1",
+            "--pretty=%h",
+            "--",
+            path.to_string_lossy().as_ref(),
+        ])
         .output()?;
-    if out.status.success() { Ok(String::from_utf8_lossy(&out.stdout).trim().to_string()) } else { anyhow::bail!("git log failed") }
+    if out.status.success() {
+        Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    } else {
+        anyhow::bail!("git log failed")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn artifact(
+        kind: &str,
+        path: &str,
+        ts: &str,
+        ttl: u64,
+        tags: &[&str],
+        branch: Option<&str>,
+        commit: Option<&str>,
+    ) -> ResearchArtifact {
+        ResearchArtifact {
+            id: format!("{}#{}", path, ttl),
+            kind: kind.to_string(),
+            path: path.to_string(),
+            ts: ts.to_string(),
+            ttl,
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            checksum: "deadbeef".into(),
+            git_commit: commit.map(|c| c.to_string()),
+            git_branch: branch.map(|b| b.to_string()),
+        }
+    }
+
+    #[test]
+    fn summary_counts_and_expiry() {
+        let now = DateTime::parse_from_rfc3339("2024-01-02T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let arts = vec![
+            artifact(
+                "doc",
+                "docs/a.md",
+                "2024-01-01T00:00:00Z",
+                86_400,
+                &["alpha"],
+                Some("main"),
+                Some("abc123"),
+            ),
+            artifact(
+                "policy",
+                "policies/b.yaml",
+                "2024-01-01T12:00:00Z",
+                172_800,
+                &["beta", "alpha"],
+                Some("dev"),
+                Some("def456"),
+            ),
+            artifact(
+                "prompt",
+                "prompts/c.md",
+                "2024-01-05T00:00:00Z",
+                0,
+                &[],
+                None,
+                None,
+            ),
+        ];
+
+        let summary = summarize(&arts, now);
+
+        assert_eq!(summary.total, 3);
+        assert_eq!(summary.by_kind.get("doc"), Some(&1));
+        assert_eq!(summary.by_kind.get("policy"), Some(&1));
+        assert_eq!(summary.by_kind.get("prompt"), Some(&1));
+        assert_eq!(summary.by_tag.get("alpha"), Some(&2));
+        assert_eq!(summary.by_tag.get("beta"), Some(&1));
+        assert_eq!(summary.untagged, 1);
+        assert_eq!(summary.missing_git_commit, 1);
+        assert_eq!(summary.by_branch.get("main"), Some(&1));
+        assert_eq!(summary.by_branch.get("dev"), Some(&1));
+        assert_eq!(summary.by_branch.get("<unknown>"), Some(&1));
+
+        let span = summary.time_span.expect("time span");
+        assert_eq!(span.earliest, "2024-01-01T00:00:00+00:00");
+        assert_eq!(span.latest, "2024-01-05T00:00:00+00:00");
+
+        assert_eq!(summary.expiring_soon.len(), 1);
+        let soon = &summary.expiring_soon[0];
+        assert_eq!(soon.path, "policies/b.yaml");
+        assert_eq!(soon.expires_at, "2024-01-03T12:00:00+00:00");
+        assert_eq!(soon.seconds_remaining, 129_600);
+
+        assert_eq!(summary.expired.len(), 1);
+        let expired = &summary.expired[0];
+        assert_eq!(expired.path, "docs/a.md");
+        assert_eq!(expired.expires_at, "2024-01-02T00:00:00+00:00");
+        assert_eq!(expired.seconds_remaining, 0);
+    }
 }


### PR DESCRIPTION
## Summary
- add a research summary aggregator that computes TTL-based freshness alerts alongside counts by kind/tag/branch
- expose optional report output through the `one-research` CLI, Makefile target, and documentation updates
- document the new workflow in the architecture context and add unit coverage for the summariser helpers

## Testing
- `cargo fmt -- engine/bin/one_research.rs engine/src/research.rs`
- `cargo test --all --locked`
- `cargo build --release`
- `cargo clippy --all-targets -- -D warnings` *(fails: repo currently contains numerous pre-existing clippy violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1cdc91870832182f48380b3b69018